### PR TITLE
fix: publiccode.yml validation errors

### DIFF
--- a/.github/workflows/publiccodeyml-check.yml
+++ b/.github/workflows/publiccodeyml-check.yml
@@ -1,0 +1,27 @@
+name: Validate publiccode.yml
+
+on:
+  push:
+    paths:
+      - "publiccode.yml"
+      - ".github/workflows/publiccodeyml-check.yml"
+  pull_request:
+    paths:
+      - "publiccode.yml"
+      - ".github/workflows/publiccodeyml-check.yml"
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: publiccode.yml validation
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: italia/publiccode-parser-action@21086c73ec0563e14c6748787efa1b34b025ad8c # v1
+        with:
+          publiccode: "publiccode.yml"
+          no-network: true

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,10 +1,13 @@
-# This repository adheres to the publiccode.yml standard by including this 
+# This repository adheres to the publiccode.yml standard by including this
 # metadata file that makes public software easily discoverable.
-# More info at https://github.com/italia/publiccode.yml
+# More info at https://github.com/publiccodeyml/publiccode.yml
 
-publiccodeYmlVersion: '0.2'
+publiccodeYmlVersion: '0'
 name: UNI.co. Easy
 url: 'https://github.com/UniCt-Easy/Easy-Uni.Co.'
+organisation:
+  name: Università degli Studi di Catania
+  uri: 'urn:x-italian-pa:uni_ct'
 releaseDate: '2022-02-22'
 developmentStatus: stable
 softwareType: standalone/other
@@ -39,7 +42,7 @@ usedBy:
   - CINIGeo
   - Consorzio Gerard Boulvert
   - CIRCC
-  - Conservatorio di Musica di Reggio Emilia e Castelnovo ne’ Monti 
+  - "Conservatorio di Musica di Reggio Emilia e Castelnovo ne' Monti"
   - Fondazione Scuola Beni e Attività Culturali
   - Conservatorio di Modena
   - Conservatorio di Aosta
@@ -47,15 +50,16 @@ usedBy:
   - Centro Nazionale di Ricerca in HPC, Big Data and Quantum Computing
   - Centro InterUniversitario per la Previsione e Prevenzione Grandi Rischi
   - Accademia di Belle Arti di Frosinone
-  - Centro Nazionale di Ricerca per le Tecnologie dell’Agricoltura
+  - Centro Nazionale di Ricerca per le Tecnologie dell'Agricoltura
   - MOST (Centro Nazionale per la Mobilità Sostenibile)
 
 maintenance:
   type: contract
   contacts:
-    - name: 'Sonia Lombardo, Gianni Smaldino'
+    - name: Sonia Lombardo
       email: easy.github@unict.it
-      phone: '+390802460212'
+    - name: Gianni Smaldino
+      email: easy.github@unict.it
   contractors:
     - name: Tempo srl
       until: '2027-07-24'
@@ -63,10 +67,9 @@ maintenance:
 legal:
   license: GPL-3.0-or-later
   mainCopyrightOwner: Università degli Studi di Catania
-  repoOwner: Università degli Studi di Catania
 intendedAudience:
   countries:
-    - it
+    - IT
   scope:
     - finance-and-economic-development
     - government
@@ -74,21 +77,8 @@ localisation:
   localisationReady: false
   availableLanguages:
     - it
-it:
-  countryExtensionVersion: "0.2"
-  riuso:
-    codiceIPA: uni_ct
-  piattaforme:
-    pagopa: true
-    spid: false
-  conforme:
-    lineeGuidaDesign: true
-    misureMinimeSicurezza: true
-    modelloInteroperabilita: true
-    gdpr: true
 description:
   it:
-    genericName: UNI.co. Easy  Co.fi. Co.an. Co.ge.
     shortDescription: >-
       UNI.CO. Easy (contabilità CO.FI. CO.AN. CO.GE.) Gestione della contabilità
       : finanziaria, economico-patrimoniale, analitica.
@@ -98,145 +88,143 @@ description:
       autorizzare e controllare preventivamente l'assunzione di nuovi impegni e
       costi. E' particolarmente indicato per le Aziende Sanitarie, le
       Università, le Fondazioni di diritto privato a totale partecipazione
-      pubblica.  Il controllo autorizzatorio del budget in corso d’esercizio
+      pubblica.  Il controllo autorizzatorio del budget in corso d'esercizio
       avviene attraverso la registrazione di Impegni e Accertamenti di Budget,
       che in Easy vengono generati automaticamente al salvataggio dei documenti
-      amministrativi che richiedono l’accantonamento di una certa quota di
+      amministrativi che richiedono l'accantonamento di una certa quota di
       budget; ad esempio un ordine a fornitore, un contratto per prestazione
-      occasionale, una missione, ecc…  Al salvataggio di ciascun documento, Easy
-      effettua un controllo sul budget disponibile annuale e pluriennale e
+      occasionale, una missione, ecc...  Al salvataggio di ciascun documento,
+      Easy effettua un controllo sul budget disponibile annuale e pluriennale e
       blocca (in funzione delle regole parametrizzate sulla base delle esigenze
       dell'ente) eventualmente il salvataggio, qualora la disponibilità risulti
       insufficiente. Ogni modifica di un documento genera in automatico delle
       variazioni agli Impegni o Accertamenti di budget. In Easy la gestione
       della Contabilità Economico-Patrimoniale risulta particolarmente semplice
-      dal punto di vista dell’utente, in quanto la generazione delle scritture
-      in partita doppia avviene automaticamente all’atto del salvataggio di un
-      documento amministrativo. L’utente dovrà  solo preoccuparsi  di indicare
-      nel documento che sta  registrando la causale EP più idonea rispetto alla 
-      natura  dell’acquisto, della   vendita o  dell’operazione che  sta
-      eﬀettuando. Grazie a preventive conﬁgurazioni inserite a monte, la
+      dal punto di vista dell'utente, in quanto la generazione delle scritture
+      in partita doppia avviene automaticamente all'atto del salvataggio di un
+      documento amministrativo. L'utente dovrà solo preoccuparsi di indicare
+      nel documento che sta registrando la causale EP più idonea rispetto alla
+      natura dell'acquisto, della vendita o dell'operazione che sta
+      effettuando. Grazie a preventive configurazioni inserite a monte, la
       scrittura in partita doppia verrà generata automaticamente. In Easy è
-      disponibile la reportistica Uﬃciale relativa alla Contabilità
-      Economico-Patrimoniale (Conto Economico, Stato Patrimonia- le, Rendiconto
-      Finanziario, Libro degli  Inventari); Sono  disponibili inoltre una serie
-      di stampe e procedure di esportazione non uﬃciali, che facilitano e
-      supportano le veriﬁche e i monitoraggi periodici svolti dagli uﬃci
+      disponibile la reportistica Ufficiale relativa alla Contabilità
+      Economico-Patrimoniale (Conto Economico, Stato Patrimoniale, Rendiconto
+      Finanziario, Libro degli Inventari); Sono disponibili inoltre una serie
+      di stampe e procedure di esportazione non ufficiali, che facilitano e
+      supportano le verifiche e i monitoraggi periodici svolti dagli uffici
       interessati. Contabilità Analitica In Easy la contabilità analitica è già
-      insita  nella  gestione del bilancio basata su due dimensioni: il centro
-      di contabilità analitica, denominato UPB, e la voce di bilancio. Sarà 
-      quindi  possibile ottenere per  ciascuna UPB e\o per  ciascun  ramo  di
-      UPB, un budget pluriennale economico e degli  investimenti autorizzatorio,
-      un Conto economico e uno Stato patrimoniale, ecc… E’ possibile infatti
-      conﬁgurare n Piani dei conti di contabilità analitica, ognuno gerarchico e
-      ad  n livelli, liberamente deﬁnibile. Su tutti i documenti di  rilevazione
-      (Fattura,  Contratto  passivo, Compenso, Impegno di Budget, ecc… ) di Easy
+      insita nella gestione del bilancio basata su due dimensioni: il centro
+      di contabilità analitica, denominato UPB, e la voce di bilancio. Sarà
+      quindi possibile ottenere per ciascuna UPB e/o per ciascun ramo di
+      UPB, un budget pluriennale economico e degli investimenti autorizzatorio,
+      un Conto economico e uno Stato patrimoniale, ecc... E' possibile infatti
+      configurare n Piani dei conti di contabilità analitica, ognuno gerarchico e
+      ad n livelli, liberamente definibile. Su tutti i documenti di rilevazione
+      (Fattura, Contratto passivo, Compenso, Impegno di Budget, ecc...) di Easy
       può essere rilevato il conto del o dei piani dei conti di contabilità
-      analitica previamente conﬁgurati. Contabilità finanziaria In Easy è
-      possibile gestire la contabilità ﬁnanziaria autorizzatoria e tutta la
-      relativa reportistica. E’ un modulo integrato ma indipendente dagli altri
-      moduli e di cui non è obbligatoria l’attivazione. La contabilità
+      analitica previamente configurati. Contabilità finanziaria In Easy è
+      possibile gestire la contabilità finanziaria autorizzatoria e tutta la
+      relativa reportistica. E' un modulo integrato ma indipendente dagli altri
+      moduli e di cui non è obbligatoria l'attivazione. La contabilità
       finanziaria può essere alternativa o contemporanea al budget
       autorizzatorio. Il modello di contabilità finanziaria implementato è
-      perfattamente aderente al DL 118 e successivi aggionamenti. Fattura
+      perfettamente aderente al DL 118 e successivi aggiornamenti. Fattura
       Elettronica e conservazione sostitutiva La ricezione delle fatture
-      elettroniche e delle relative notiﬁche provenienti dal Sistema di
-      Interscambio, viene gestita in Easy da un servizio  completamente
+      elettroniche e delle relative notifiche provenienti dal Sistema di
+      Interscambio, viene gestita in Easy da un servizio completamente
       automatizzato che riceve e raccoglie in una tabella le fatture di acquisto
       ricevute sullo SDI. In Easy è inoltre possibile emettere fatture
-      elettroniche attive e generare il ﬁle XML secondo il formato stabilito dal
-      tracciato del sistema di interscambio. Tale ﬁle viene protocollato e
+      elettroniche attive e generare il file XML secondo il formato stabilito dal
+      tracciato del sistema di interscambio. Tale file viene protocollato e
       inviato automaticamente al SDI. Il servizio di gestione delle fatture
       elettroniche è perfettamente integrato con il servizio Aruba DocFly la
       conservazione sostitutiva a norma di legge. Il processo è completamente
       automatizzato per sollevare gli operatori dalla possibilità di commettere
-      omissioni o ritardi nell’invio in conservazioneTrasparenza Adempimenti
-      ANAC EasyWeb  esporta tali dati mediante tre procedure in grado di
+      omissioni o ritardi nell'invio in conservazione. Trasparenza Adempimenti
+      ANAC EasyWeb esporta tali dati mediante tre procedure in grado di
       restituire i dati in tre formati aperti: xml, json ed html. Le tre
       esportazioni, completamente parametriche, sono implementate in maniera
-      tale da facilitare l’integrazione con il partale dell'Ente nella sezione
-      “Amministrazione Trasparente” rispondendo all’esigenza di automatizzare la
+      tale da facilitare l'integrazione con il portale dell'Ente nella sezione
+      "Amministrazione Trasparente" rispondendo all'esigenza di automatizzare la
       pubblicazione dei dati con la tempestività richiesta.  Easy è in grado di
-      produrre in maniera semplice il ﬁle XML per  la pubblicazione ai ﬁni
-      della  legge 190 secondo le speciﬁche tecniche. Il ﬁle risultante quindi
-      non richiede ulteriori modiﬁche da parte dell’utente e può essere
+      produrre in maniera semplice il file XML per la pubblicazione ai fini
+      della legge 190 secondo le specifiche tecniche. Il file risultante quindi
+      non richiede ulteriori modifiche da parte dell'utente e può essere
       pubblicato sul portale di ogni tipologia di Ente per la validazione da
-      parte dell’ANAC.  Trasparenza l modulo di Gestione degli Incarichi prevede
-      una gestione completa e parametrica degli adempimenti di comunicazione al
-      Dipartimento della Funzione Pubblica. Per gli obblighi di comunicazione è
-      previsto l’utilizzo di procedure informatiche che consentono la
-      generazione di un ﬁle XML. Il ﬁle prodotto da Easy potrà essere trasmesso
-      al Dipartimento della Funzione Pubblica tramite il sito PERLA PA
-      Piattaforma di Certificazione dei Crediti Con l’introduzione della 
-      fattura elettronica il trasferimento dei dati delle fatture avviene in
-      modo automatico tra SDI e sistema PCC pertanto le pubbliche
+      parte dell'ANAC.  Trasparenza il modulo di Gestione degli Incarichi
+      prevede una gestione completa e parametrica degli adempimenti di
+      comunicazione al Dipartimento della Funzione Pubblica. Per gli obblighi
+      di comunicazione è previsto l'utilizzo di procedure informatiche che
+      consentono la generazione di un file XML. Il file prodotto da Easy potrà
+      essere trasmesso al Dipartimento della Funzione Pubblica tramite il sito
+      PERLA PA. Piattaforma di Certificazione dei Crediti Con l'introduzione
+      della fattura elettronica il trasferimento dei dati delle fatture avviene
+      in modo automatico tra SDI e sistema PCC pertanto le pubbliche
       amministrazioni, tra cui le università, saranno tenute a tracciare le
-      operazioni che interessano il ciclo di vita dei debiti . A tal ﬁne in Easy
+      operazioni che interessano il ciclo di vita dei debiti. A tal fine in Easy
       sono presenti le funzionalità che consentono di produrre, sulla base dei
-      dati inseriti nella gestione contabile, i ﬁles .CSV previsti per  il
+      dati inseriti nella gestione contabile, i files .CSV previsti per il
       caricamento massimo delle suddette operazioni sul sistema PCC. SIOPE+ -
-      Sistema di Monitoraggio dei debiti commerciali Al ﬁne di favorire il
+      Sistema di Monitoraggio dei debiti commerciali Al fine di favorire il
       monitoraggio del ciclo completo delle entrate e delle spese, le
       amministrazioni pubbliche ordinano gli incassi e i pagamenti al proprio
       tesoriere o cassiere esclusivamente attraverso ordinativi informatici
       emessi secondo lo standard emanato da AGID, per il tramite
-      dell’infrastruttura della “banca dati SIOPE” gestita da Banca d’Italia
-      nell’ambito della tesoreria statale. Pago - PA In Easy è già implementato
-      il servizio  di interfaccia per  collegare l’applicativo con diversi 
+      dell'infrastruttura della "banca dati SIOPE" gestita da Banca d'Italia
+      nell'ambito della tesoreria statale. Pago-PA In Easy è già implementato
+      il servizio di interfaccia per collegare l'applicativo con diversi
       partner ed è predisposto uno strumento di controllo della capacità di
       spesa, per ciascuna struttura decentrata, che simuli in qualche modo la
-      gestione di conti correnti separati.  - Gestione delle imposte -
-      Liquidazione periodica delle imposte e relativo versamento. - Strumenti di
-      gestione e visualizzazione delle ritenute applicate e da versare. -
-      Versamento delle imposte mediate F24 EP (Enti Pubblici). - Generazione  
-      del    ﬁle    telematico  dell’E-Mens    consolidato - d’Ateneo. -
-      Generazione  del   ﬁle   telematico  per   la  redazione del   770
-      sempliﬁcato. - Gestione e liquidazione dei compensi a parasubordinati,
-      c/terzi e supplenze. - Predisposizione della  certiﬁcazione unica  dei
-      redditi da lavoro - dipendente (modello CUD). - Gestione e liquidazione
-      delle missioni,  in  Italia  e all’estero, - svolte da personale
-      strutturato e non strutturato. - Procedure   di   esportazione   dei   
-      pagamenti  eﬀettuati   a dipendenti strutturati verso altro software degli
-      stipendi per un successivo conguaglio.  Magazzino Il modulo Magazzino
+      gestione di conti correnti separati. Gestione delle imposte Liquidazione
+      periodica delle imposte e relativo versamento. Strumenti di gestione e
+      visualizzazione delle ritenute applicate e da versare. Versamento delle
+      imposte mediante F24 EP (Enti Pubblici). Generazione del file telematico
+      dell'E-Mens consolidato d'Ateneo. Generazione del file telematico per la
+      redazione del 770 semplificato. Gestione e liquidazione dei compensi a
+      parasubordinati, c/terzi e supplenze. Predisposizione della
+      certificazione unica dei redditi da lavoro dipendente (modello CUD).
+      Gestione e liquidazione delle missioni, in Italia e all'estero, svolte da
+      personale strutturato e non strutturato. Procedure di esportazione dei
+      pagamenti effettuati a dipendenti strutturati verso altro software degli
+      stipendi per un successivo conguaglio. Magazzino Il modulo Magazzino
       permette di implementare la contabilità di magazzino prevedendo diverse
       funzionalità relative alla gestione dei movimenti di carico e scarico,
       gestione dei DDT, gestione degli articoli di magazzino, gestione delle
-      quantità inevase e quantità di stock. Il modulo è integrato  con il modulo
-      IVA per la gestione delle fatture accompagnatorie e diﬀerite e il modulo
-      ﬁnanziario per l’ordinazione il regolamento degli ordinativi di
-      fornitura.  Il modulo di magazzino prevede un sistema di priorità di
-      prenotazioni, in base all’ordine di arrivo. Una prenotazione si riferisce
+      quantità inevase e quantità di stock. Il modulo è integrato con il modulo
+      IVA per la gestione delle fatture accompagnatorie e differite e il modulo
+      finanziario per l'ordinazione il regolamento degli ordinativi di
+      fornitura. Il modulo di magazzino prevede un sistema di priorità di
+      prenotazioni, in base all'ordine di arrivo. Una prenotazione si riferisce
       ad un magazzino, e ad uno o più articoli, e di ognuno è possibile
-      speciﬁcare la quantità prenotata.  Fondo Economale In Easy è possibile
+      specificare la quantità prenotata. Fondo Economale In Easy è possibile
       gestire uno o più fondi piccole spese. In particolare, Easy mette a
       disposizione procedure guidate che generano contestualmente
-      pagamenti\incassi e scritture in partita doppia, in riferimento a
+      pagamenti/incassi e scritture in partita doppia, in riferimento a
       operazioni di apertura, reintegro e chiusura di ciascun fondo economale; e
       consente la gestione informatizzata del registro delle Operazioni di Fondo
-      economale Patrimonio Easy consente di informatizzare completamente la
+      economale. Patrimonio Easy consente di informatizzare completamente la
       gestione dei cespiti inventaribili e di gestire automaticamente il calcolo
-      degli ammortamenti. Per  I cespiti acquistati a fronte di un ﬁnanziamento
+      degli ammortamenti. Per i cespiti acquistati a fronte di un finanziamento
       in conto capitale, è possibile memorizzare in Easy le informazioni del
-      Contributo ricevuto e gestire automaticamente l’apertura e il consumo dei
+      Contributo ricevuto e gestire automaticamente l'apertura e il consumo dei
       Risconti passivi. Il modulo patrimonio gestisce anche la contabilizzazione
       delle donazioni con e senza vincolo di destinazione. Il modulo del
-      Patrimonio oﬀre una Reportistica completa e tutte le stampe e le procedure
-      di esportazione utili ai lavori di veriﬁca e monitoraggio della coerenza
-      delle registrazioni eﬀettuate. Moduli Web Easy dispone di un’interfaccia
-      web, alla quale si accede con le opportune credenziali, da qualsiasi luogo
-      dotato di collegamento in rete, senza che sia necessario installare Easy
-      sul proprio PC. Ad esempio un docente può consultare la Situazione
-      contabile dei propri Fondi (e solo dei suoi), accedendo ad Easy web
-      comoda- mente da casa  sua. Oppure un ricercatore può  inserire in Easy
-      web  una  Richiesta di Missione, senza recarsi necessariamente presso gli
-      uﬃci amministrativi; Via web è possibile anche inserire Richieste di
-      Variazione di Budget e Richieste di Variazione di Bilancio Finanziario. 
+      Patrimonio offre una Reportistica completa e tutte le stampe e le
+      procedure di esportazione utili ai lavori di verifica e monitoraggio della
+      coerenza delle registrazioni effettuate. Moduli Web Easy dispone di
+      un'interfaccia web, alla quale si accede con le opportune credenziali, da
+      qualsiasi luogo dotato di collegamento in rete, senza che sia necessario
+      installare Easy sul proprio PC. Ad esempio un docente può consultare la
+      Situazione contabile dei propri Fondi (e solo dei suoi), accedendo ad Easy
+      web comodamente da casa sua. Oppure un ricercatore può inserire in Easy
+      web una Richiesta di Missione, senza recarsi necessariamente presso gli
+      uffici amministrativi; Via web è possibile anche inserire Richieste di
+      Variazione di Budget e Richieste di Variazione di Bilancio Finanziario.
     features:
       - Budget autorizzatorio annuale e pluriennale
       - Contabilità Finanziaria
-      - Contabilità IVA, Istituzionale, Commerciale, Prorata, Promiscuo, Intra \
-        Extra UE
-      - Comunicazione periodica liquidazione IVA  (Li.Pe Xml ), Esterometro Xml
+      - Contabilità IVA, Istituzionale, Commerciale, Prorata, Promiscuo, Intra/Extra UE
+      - Comunicazione periodica liquidazione IVA (Li.Pe Xml), Esterometro Xml
       - Compensi occasionali, professionali, parasubordinati
       - Liquidazione ritenute, certificazione unica
       - Gestione magazzino
@@ -245,7 +233,7 @@ description:
         Gestione cespiti (calcolo automatico ammortamenti e contributi agli
         investimenti)
       - Fondo economale
-      - 'Gestione flussi con la Banca - Supporto completo a Siope + '
+      - Gestione flussi con la Banca - Supporto completo a Siope+
       - Riconciliazione automatica degli incassi provenienti da PagoPA
       - Portale Web per la vendita di servizi e transazioni PagoPA
       - Gestione integrata della fatturazione elettronica (Canale SDIFtp)


### PR DESCRIPTION
An unquoted apostrophe in the `usedBy` list caused a YAML parse error. `maintenance.contacts` had two names crammed into one entry.